### PR TITLE
feat: citizen_signal_async tier-3 example + three-level book framing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [ "crates/egui_mobius", "crates/egui_mobius_widgets",
     "examples/citizen_fetch",
     "examples/filter_plotter",
     "examples/getting_started",
+    "examples/citizen_signal_async",
     "examples"
 ]
 # exclude = [

--- a/book/book.toml
+++ b/book/book.toml
@@ -2,7 +2,7 @@
 authors = ["James Bonanno"]
 language = "en"
 src = "src"
-title = "egui-citizen"
+title = "egui-mobius && egui-citizen"
 description = "A framework for clean, reusable architecture in egui apps — identities, reactive state, and message dispatch."
 
 [output.html]

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,7 +1,12 @@
 # Introduction
 
+This book provides know-how to build solid professional graphical user
+interfaces with the Rust programming languge employing the `egui` GUI library. `egui_mobius` is a framwork ecosystem that has been in solid use now approaching two years. 
+
 `egui_mobius` primarily consists of itself, `egui_mobius_reactive`, and `egui_citizen.` The citizen crate is a design pattern on top of egui_mobius_reactive which facilitates robust development of 
 flexible, maintainable applications. 
+
+
 
 Overall egui_citizen is the preferred general pattern of working with egui_mobius in the sense that most modern applications will typically have dockable panels to make the Ui ergonomic and modern. Coupled with background threading, these are the two primary focus areas of GUI design, well supported by the citizen pattern: 
 
@@ -10,6 +15,7 @@ Overall egui_citizen is the preferred general pattern of working with egui_mobiu
 
 This book goes through `egui_citizen` and `egui_mobius_reactive` to illustrate the fundamental design pattern and provide explanations of the underlying code so that one knows what the framework and patterns are doing under the hood. 
 
+
 ![CopperForge running on egui_citizen — a docked layout with a 3D gerber view, settings, terminal, and logger panels updating live as the user drives the app.](images/citizen-copper.gif)
 
 *[CopperForge](https://github.com/Atlantix-EDA/CopperForge) — a
@@ -17,6 +23,22 @@ real-world `egui_citizen` + `egui_dock` application for PCB gerber
 inspection. Each docked region is a citizen-panel; the panels share
 state through reactive cells, and the 3D rendering thread is
 coordinated through the dispatcher.*
+
+
+It must also be noted that there are three general levels to a mobius-citizen application. One is
+where shared state is between panels, and the dispatcher simply does
+state management of panels. A second is where the dispatcher is extended
+to handle backend processing. Finally the third level is where signals
+and slots are employed between the dispatcher and the backend. The
+first two stages employ citizen and mobius_reactive while the third
+stage uses all elements of the ecosystem. Thus the signals and slots
+are explored via `egui_mobius` for third level applications.
+
+Worked examples for each level live in `examples/`:
+
+- **Level 1** — `getting_started`, `citizen_dock`
+- **Level 2** — `filter_plotter`, `citizen_fetch`
+- **Level 3** — `citizen_signal_async`
 
 This guide is written organically, with the human focus, and is meant to be free-flowing and logical and yet easy to read. 
 
@@ -50,7 +72,7 @@ approaches.
 
 `egui_mobius` Signals and Slots can be employed by the dispatcher for
 more advanced applications, in which case there is likely multiple background threads all receiving a signal from the dispatcher. Each
-background thread cand then send a Signal back to a Slot on the dispatcher for task / thread completion. 
+background thread can then send a Signal back to a Slot on the dispatcher for task / thread completion. 
 
 This book presents background material related to an examination of 
 `Dynamic<T>`, `egui_dock`, and general vocabulary associated with the

--- a/examples/citizen_signal_async/Cargo.toml
+++ b/examples/citizen_signal_async/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "citizen_signal_async"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+egui_mobius          = { workspace = true }
+egui_mobius_reactive = { workspace = true }
+egui_citizen         = { workspace = true }
+egui                 = { workspace = true }
+egui_dock            = { workspace = true }
+eframe               = { workspace = true, features = ["default"] }
+tokio                = { version = "1", features = ["full"] }

--- a/examples/citizen_signal_async/src/backend.rs
+++ b/examples/citizen_signal_async/src/backend.rs
@@ -1,0 +1,55 @@
+//! Async backend: receives a `WorkRequest` off the signal bus, sleeps
+//! to simulate work, returns a `WorkResponse`.
+//!
+//! `wire_backend` builds the full Tokio-backed pipeline and returns the
+//! UI-side handles: a `Signal<WorkRequest>` the UI uses to submit work,
+//! and a `Slot<WorkResponse>` the UI starts to receive completions on.
+//! The returned `BackendHandle` owns the `AsyncDispatcher` so the Tokio
+//! runtime stays alive for the program duration.
+
+use std::time::{Duration, Instant};
+
+use egui_mobius::dispatching::AsyncDispatcher;
+use egui_mobius::factory;
+use egui_mobius::signals::Signal;
+use egui_mobius::slot::Slot;
+
+use crate::state::{WorkRequest, WorkResponse};
+
+/// The async work function. Sleeps for `req.duration_ms` then computes
+/// `sin(seed * 2π)` as a stand-in for "real" backend computation. The
+/// elapsed time is measured wall-clock so a UI smoke test can confirm
+/// the request actually went off-thread.
+async fn work(req: WorkRequest) -> WorkResponse {
+    let started = Instant::now();
+    tokio::time::sleep(Duration::from_millis(req.duration_ms as u64)).await;
+    let value = (req.seed * 2.0 * std::f64::consts::PI).sin();
+    WorkResponse {
+        value,
+        elapsed_ms: started.elapsed().as_millis() as u32,
+    }
+}
+
+/// Owns the `AsyncDispatcher` so the Tokio runtime it spun up stays
+/// alive for the program duration. Drop this and the runtime dies and
+/// queued work goes silent.
+pub struct BackendHandle {
+    _dispatcher: AsyncDispatcher<WorkRequest, WorkResponse>,
+}
+
+/// Build the work pipeline. Returns:
+/// - `Signal<WorkRequest>` — UI thread submits work via `.send(req)`
+/// - `Slot<WorkResponse>` — UI thread calls `.start(handler)` on this
+///   to receive completions and update `SharedState`
+/// - `BackendHandle` — keep alive on the App struct
+pub fn wire_backend() -> (Signal<WorkRequest>, Slot<WorkResponse>, BackendHandle) {
+    let (work_signal,   work_slot)   = factory::create_signal_slot::<WorkRequest>();
+    let (result_signal, result_slot) = factory::create_signal_slot::<WorkResponse>();
+
+    let dispatcher = AsyncDispatcher::<WorkRequest, WorkResponse>::new();
+    dispatcher.attach_async(work_slot, result_signal, |req| async move {
+        work(req).await
+    });
+
+    (work_signal, result_slot, BackendHandle { _dispatcher: dispatcher })
+}

--- a/examples/citizen_signal_async/src/dispatcher.rs
+++ b/examples/citizen_signal_async/src/dispatcher.rs
@@ -12,13 +12,7 @@ use egui_mobius_reactive::Dynamic;
 
 use crate::messages::AppMessage;
 use crate::state::{SharedState, WorkRequest};
-
-// Citizen IDs. These will move to `tabs.rs` in Phase 3 alongside the
-// `TabKind` enum and `TabViewer` impl; keeping them here for now so the
-// dispatcher module is self-contained until the dock layout exists.
-pub const CONTROL_ID: &str = "control";
-pub const RESULT_ID:  &str = "result";
-pub const LOGGER_ID:  &str = "logger";
+use crate::tabs::{CONTROL_ID, LOGGER_ID, RESULT_ID};
 
 /// The three CitizenStates the panels need to hold, kept together so
 /// `App::new()` doesn't have to thread three values out of

--- a/examples/citizen_signal_async/src/dispatcher.rs
+++ b/examples/citizen_signal_async/src/dispatcher.rs
@@ -1,0 +1,122 @@
+//! Dispatcher wiring: register citizens at startup, drain lifecycle
+//! messages each frame, route AppMessage events to the work signal.
+//!
+//! Mirrors `filter_plotter::dispatcher` deliberately. The difference is
+//! that the work boundary here is a `Signal<WorkRequest>` (cross-thread,
+//! async via `egui_mobius`'s signal/slot bus) rather than a synchronous
+//! `BackendKind` trait object run inline on the UI thread.
+
+use egui_citizen::{CitizenId, CitizenMessage, CitizenState, Dispatcher};
+use egui_mobius::Signal;
+use egui_mobius_reactive::Dynamic;
+
+use crate::messages::AppMessage;
+use crate::state::{SharedState, WorkRequest};
+
+// Citizen IDs. These will move to `tabs.rs` in Phase 3 alongside the
+// `TabKind` enum and `TabViewer` impl; keeping them here for now so the
+// dispatcher module is self-contained until the dock layout exists.
+pub const CONTROL_ID: &str = "control";
+pub const RESULT_ID:  &str = "result";
+pub const LOGGER_ID:  &str = "logger";
+
+/// The three CitizenStates the panels need to hold, kept together so
+/// `App::new()` doesn't have to thread three values out of
+/// `register_citizens`.
+pub struct RegisteredCitizens {
+    pub control: CitizenState,
+    pub result:  CitizenState,
+    pub logger:  CitizenState,
+}
+
+/// Register the three citizens with the dispatcher and activate
+/// `control` as the default focus. Returns the panel-bound state
+/// handles.
+pub fn register_citizens(dispatcher: &mut Dispatcher) -> RegisteredCitizens {
+    let control = dispatcher.register(CitizenId::new(CONTROL_ID));
+    let result  = dispatcher.register(CitizenId::new(RESULT_ID));
+    let logger  = dispatcher.register(CitizenId::new(LOGGER_ID));
+
+    dispatcher.activate(&CitizenId::new(CONTROL_ID));
+
+    RegisteredCitizens { control, result, logger }
+}
+
+/// Drain citizen lifecycle messages and append them to the shared log.
+/// Call once per frame after `DockArea::show`.
+pub fn drain_citizen(dispatcher: &mut Dispatcher, log: &Dynamic<Vec<String>>) {
+    for msg in dispatcher.drain_messages() {
+        append_log(log, format_citizen(&msg));
+    }
+}
+
+/// Route an app-level message. `Compute` snapshots the params and
+/// pushes a `WorkRequest` onto the signal bus; the backend slot picks
+/// it up off the UI thread. `BackendCompleted` logs the completion —
+/// the actual result has already been written to `state.last_result`
+/// by the slot handler that received the response.
+pub fn handle(
+    msg: AppMessage,
+    state: &SharedState,
+    work_signal: &Signal<WorkRequest>,
+    log: &Dynamic<Vec<String>>,
+) {
+    match msg {
+        // Already drained directly via `drain_citizen`.
+        AppMessage::Citizen(_) => {}
+
+        AppMessage::Compute => {
+            let req = state.params.snapshot();
+            state.in_flight.set(true);
+            append_log(
+                log,
+                format!(
+                    "[ui] submit: duration_ms={}, seed={:.4}",
+                    req.duration_ms, req.seed,
+                ),
+            );
+            if let Err(e) = work_signal.send(req) {
+                append_log(log, format!("[ui] send failed: {e}"));
+                state.in_flight.set(false);
+            }
+        }
+
+        AppMessage::BackendCompleted { value, elapsed_ms } => {
+            append_log(
+                log,
+                format!(
+                    "[ui] backend completed: value={:.4} elapsed_ms={}",
+                    value, elapsed_ms,
+                ),
+            );
+        }
+    }
+}
+
+const MAX_LOG_LINES: usize = 500;
+
+/// Append a line to the log, capped at `MAX_LOG_LINES` so memory stays
+/// bounded over long sessions.
+pub fn append_log(log: &Dynamic<Vec<String>>, line: String) {
+    let mut buf = log.get();
+    buf.push(line);
+    if buf.len() > MAX_LOG_LINES {
+        let drop = buf.len() - MAX_LOG_LINES;
+        buf.drain(0..drop);
+    }
+    log.set(buf);
+}
+
+fn format_citizen(msg: &CitizenMessage) -> String {
+    match msg {
+        CitizenMessage::Activated   { id } => format!("[citizen] {} activated",   id),
+        CitizenMessage::Deactivated { id } => format!("[citizen] {} deactivated", id),
+        CitizenMessage::Clicked     { id } => format!("[citizen] {} clicked",     id),
+        CitizenMessage::Selected    { id, selected } =>
+            format!("[citizen] {} selected={}", id, selected),
+        CitizenMessage::Moved       { id, location } =>
+            format!("[citizen] {} moved to [{:.1}, {:.1}]", id, location[0], location[1]),
+        CitizenMessage::VisibilityChanged { id, visible } =>
+            format!("[citizen] {} visible={}", id, visible),
+    }
+}

--- a/examples/citizen_signal_async/src/main.rs
+++ b/examples/citizen_signal_async/src/main.rs
@@ -1,0 +1,8 @@
+//! citizen_signal_async — citizen pattern + egui_mobius signal/slot + Tokio backend.
+//!
+//! Scaffold only. See `task_plan.md` for the design and
+//! `task_progress.md` for the build checklist.
+
+fn main() {
+    println!("citizen_signal_async — scaffold only. See task_plan.md.");
+}

--- a/examples/citizen_signal_async/src/main.rs
+++ b/examples/citizen_signal_async/src/main.rs
@@ -1,46 +1,72 @@
 //! citizen_signal_async — citizen pattern + egui_mobius signal/slot + Tokio backend.
 //!
-//! Phase 2 — eframe shell + backend wiring + smoke-test central panel.
-//! The three-citizen dock layout (Control / Result / Logger) follows in
-//! Phase 3; for now everything renders into a single `CentralPanel` so
-//! the cross-thread bus can be exercised end to end.
+//! Phase 3 — three docked citizens (Control / Result / Logger) wired
+//! through `egui_dock`'s `TabViewer`. Tab clicks forward to
+//! `Dispatcher::activate` so citizen lifecycle messages flow through
+//! the drain loop and end up in the Logger panel.
+//!
+//! Click Compute on the Control panel → AppMessage::Compute hits the
+//! outbox → drain loop forwards via `work_signal.send(req)` → backend
+//! runs on Tokio → `result_signal` carries the response back → result
+//! slot writes `last_result` and `in_flight` on `SharedState` and
+//! requests a UI repaint.
 
 mod backend;
 mod dispatcher;
 mod messages;
+mod panels;
 mod state;
+mod tabs;
 
 use eframe::egui;
 use egui_citizen::Dispatcher as CitizenDispatcher;
+use egui_dock::{DockArea, DockState, NodeIndex};
 use egui_mobius::signals::Signal;
 
-use crate::messages::AppMessage;
+use crate::panels::{control::ControlPanel, logger::LoggerPanel, result::ResultPanel};
 use crate::state::{SharedState, WorkRequest};
+use crate::tabs::{Tab, TabKind, TabViewer};
 
 struct App {
     dispatcher: CitizenDispatcher,
+    dock_state: DockState<Tab>,
     state: SharedState,
     work_signal: Signal<WorkRequest>,
     /// Keeps the Tokio runtime alive. Dropping this silences the backend.
     _backend: backend::BackendHandle,
-    /// Outbox of AppMessages produced this frame; drained at end of `update()`.
-    outbox: Vec<AppMessage>,
+    control: ControlPanel,
+    result:  ResultPanel,
+    logger:  LoggerPanel,
 }
 
 impl App {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
         let state = SharedState::new();
 
-        // Citizen dispatcher — registered citizens exist now even though
-        // panels won't be wired to them until Phase 3. The handles
-        // (`_citizens`) are intentionally discarded for now.
         let mut dispatcher = CitizenDispatcher::new();
-        let _citizens = dispatcher::register_citizens(&mut dispatcher);
+        let citizens = dispatcher::register_citizens(&mut dispatcher);
 
-        // Build the cross-thread bus.
+        // Dock layout:
+        //   ┌──────────────┬─────────────┐
+        //   │              │   Control   │
+        //   │    Result    ├─────────────┤
+        //   │              │   Logger    │
+        //   └──────────────┴─────────────┘
+        let mut dock_state = DockState::new(vec![Tab::new(TabKind::Result)]);
+        let [_, right] = dock_state.main_surface_mut().split_right(
+            NodeIndex::root(),
+            0.6,
+            vec![Tab::new(TabKind::Control)],
+        );
+        let [_, _bottom] = dock_state.main_surface_mut().split_below(
+            right,
+            0.5,
+            vec![Tab::new(TabKind::Logger)],
+        );
+
         let (work_signal, mut result_slot, backend_handle) = backend::wire_backend();
 
-        // Result slot handler — runs on the slot's worker thread when a
+        // Result-slot handler — runs on the slot's worker thread when a
         // backend response arrives. Writes through the shared `Dynamic`
         // handles, then wakes the UI so the new value paints next frame.
         let last_result = state.last_result.clone();
@@ -64,70 +90,34 @@ impl App {
 
         Self {
             dispatcher,
+            dock_state,
             state,
             work_signal,
             _backend: backend_handle,
-            outbox: Vec::new(),
+            control: ControlPanel::new(citizens.control),
+            result:  ResultPanel::new(citizens.result),
+            logger:  LoggerPanel::new(citizens.logger),
         }
     }
 }
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("citizen_signal_async — smoke test");
-            ui.add_space(8.0);
+        DockArea::new(&mut self.dock_state).show(
+            ctx,
+            &mut TabViewer {
+                state: &self.state,
+                dispatcher: &mut self.dispatcher,
+                control: &mut self.control,
+                result:  &mut self.result,
+                logger:  &mut self.logger,
+            },
+        );
 
-            // Sliders bind to the reactive params via the standard
-            // get / set pattern.
-            let mut dur = self.state.params.work_duration_ms.get();
-            if ui
-                .add(egui::Slider::new(&mut dur, 50..=3000).text("duration_ms"))
-                .changed()
-            {
-                self.state.params.work_duration_ms.set(dur);
-            }
-
-            let mut seed = self.state.params.seed.get();
-            if ui
-                .add(egui::Slider::new(&mut seed, 0.0..=1.0).text("seed"))
-                .changed()
-            {
-                self.state.params.seed.set(seed);
-            }
-
-            ui.add_space(8.0);
-            ui.horizontal(|ui| {
-                if ui.button("Compute").clicked() {
-                    self.outbox.push(AppMessage::Compute);
-                }
-                if self.state.in_flight.get() {
-                    ui.spinner();
-                    ui.label("in flight…");
-                }
-            });
-
-            ui.add_space(8.0);
-            ui.label(format!("last result: {:.6}", self.state.last_result.get()));
-
-            ui.add_space(12.0);
-            ui.separator();
-            ui.label("Log:");
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, false])
-                .stick_to_bottom(true)
-                .show(ui, |ui| {
-                    for line in self.state.log.get().iter() {
-                        ui.monospace(line);
-                    }
-                });
-        });
-
-        // Drain pass — once per frame, after the UI has rendered and
-        // any in-frame events have queued.
+        // Drain pass — once per frame, after the dock has rendered.
         dispatcher::drain_citizen(&mut self.dispatcher, &self.state.log);
 
-        let outbox = std::mem::take(&mut self.outbox);
+        let outbox = std::mem::take(&mut self.control.outbox);
         for msg in outbox {
             dispatcher::handle(msg, &self.state, &self.work_signal, &self.state.log);
         }
@@ -139,8 +129,8 @@ fn main() -> Result<(), eframe::Error> {
         "citizen_signal_async",
         eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
-                .with_inner_size([900.0, 600.0])
-                .with_min_inner_size([600.0, 400.0]),
+                .with_inner_size([1000.0, 650.0])
+                .with_min_inner_size([700.0, 450.0]),
             ..Default::default()
         },
         Box::new(|cc| Ok(Box::new(App::new(cc)))),

--- a/examples/citizen_signal_async/src/main.rs
+++ b/examples/citizen_signal_async/src/main.rs
@@ -1,8 +1,12 @@
 //! citizen_signal_async — citizen pattern + egui_mobius signal/slot + Tokio backend.
 //!
-//! Scaffold only. See `task_plan.md` for the design and
-//! `task_progress.md` for the build checklist.
+//! Phase 1 — types and dispatcher routing in place. eframe shell and
+//! panels follow. See `task_plan.md` and `task_progress.md`.
+
+mod dispatcher;
+mod messages;
+mod state;
 
 fn main() {
-    println!("citizen_signal_async — scaffold only. See task_plan.md.");
+    println!("citizen_signal_async — types in place; eframe shell next.");
 }

--- a/examples/citizen_signal_async/src/main.rs
+++ b/examples/citizen_signal_async/src/main.rs
@@ -1,12 +1,148 @@
 //! citizen_signal_async — citizen pattern + egui_mobius signal/slot + Tokio backend.
 //!
-//! Phase 1 — types and dispatcher routing in place. eframe shell and
-//! panels follow. See `task_plan.md` and `task_progress.md`.
+//! Phase 2 — eframe shell + backend wiring + smoke-test central panel.
+//! The three-citizen dock layout (Control / Result / Logger) follows in
+//! Phase 3; for now everything renders into a single `CentralPanel` so
+//! the cross-thread bus can be exercised end to end.
 
+mod backend;
 mod dispatcher;
 mod messages;
 mod state;
 
-fn main() {
-    println!("citizen_signal_async — types in place; eframe shell next.");
+use eframe::egui;
+use egui_citizen::Dispatcher as CitizenDispatcher;
+use egui_mobius::signals::Signal;
+
+use crate::messages::AppMessage;
+use crate::state::{SharedState, WorkRequest};
+
+struct App {
+    dispatcher: CitizenDispatcher,
+    state: SharedState,
+    work_signal: Signal<WorkRequest>,
+    /// Keeps the Tokio runtime alive. Dropping this silences the backend.
+    _backend: backend::BackendHandle,
+    /// Outbox of AppMessages produced this frame; drained at end of `update()`.
+    outbox: Vec<AppMessage>,
+}
+
+impl App {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        let state = SharedState::new();
+
+        // Citizen dispatcher — registered citizens exist now even though
+        // panels won't be wired to them until Phase 3. The handles
+        // (`_citizens`) are intentionally discarded for now.
+        let mut dispatcher = CitizenDispatcher::new();
+        let _citizens = dispatcher::register_citizens(&mut dispatcher);
+
+        // Build the cross-thread bus.
+        let (work_signal, mut result_slot, backend_handle) = backend::wire_backend();
+
+        // Result slot handler — runs on the slot's worker thread when a
+        // backend response arrives. Writes through the shared `Dynamic`
+        // handles, then wakes the UI so the new value paints next frame.
+        let last_result = state.last_result.clone();
+        let in_flight   = state.in_flight.clone();
+        let log         = state.log.clone();
+        let ctx         = cc.egui_ctx.clone();
+        result_slot.start(move |resp| {
+            last_result.set(resp.value);
+            in_flight.set(false);
+            dispatcher::append_log(
+                &log,
+                format!(
+                    "[backend] result: value={:.4} elapsed_ms={}",
+                    resp.value, resp.elapsed_ms,
+                ),
+            );
+            ctx.request_repaint();
+        });
+
+        dispatcher::append_log(&state.log, "[INFO] citizen_signal_async started".into());
+
+        Self {
+            dispatcher,
+            state,
+            work_signal,
+            _backend: backend_handle,
+            outbox: Vec::new(),
+        }
+    }
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("citizen_signal_async — smoke test");
+            ui.add_space(8.0);
+
+            // Sliders bind to the reactive params via the standard
+            // get / set pattern.
+            let mut dur = self.state.params.work_duration_ms.get();
+            if ui
+                .add(egui::Slider::new(&mut dur, 50..=3000).text("duration_ms"))
+                .changed()
+            {
+                self.state.params.work_duration_ms.set(dur);
+            }
+
+            let mut seed = self.state.params.seed.get();
+            if ui
+                .add(egui::Slider::new(&mut seed, 0.0..=1.0).text("seed"))
+                .changed()
+            {
+                self.state.params.seed.set(seed);
+            }
+
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                if ui.button("Compute").clicked() {
+                    self.outbox.push(AppMessage::Compute);
+                }
+                if self.state.in_flight.get() {
+                    ui.spinner();
+                    ui.label("in flight…");
+                }
+            });
+
+            ui.add_space(8.0);
+            ui.label(format!("last result: {:.6}", self.state.last_result.get()));
+
+            ui.add_space(12.0);
+            ui.separator();
+            ui.label("Log:");
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .stick_to_bottom(true)
+                .show(ui, |ui| {
+                    for line in self.state.log.get().iter() {
+                        ui.monospace(line);
+                    }
+                });
+        });
+
+        // Drain pass — once per frame, after the UI has rendered and
+        // any in-frame events have queued.
+        dispatcher::drain_citizen(&mut self.dispatcher, &self.state.log);
+
+        let outbox = std::mem::take(&mut self.outbox);
+        for msg in outbox {
+            dispatcher::handle(msg, &self.state, &self.work_signal, &self.state.log);
+        }
+    }
+}
+
+fn main() -> Result<(), eframe::Error> {
+    eframe::run_native(
+        "citizen_signal_async",
+        eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([900.0, 600.0])
+                .with_min_inner_size([600.0, 400.0]),
+            ..Default::default()
+        },
+        Box::new(|cc| Ok(Box::new(App::new(cc)))),
+    )
 }

--- a/examples/citizen_signal_async/src/messages.rs
+++ b/examples/citizen_signal_async/src/messages.rs
@@ -1,0 +1,21 @@
+//! App-level messages. `AppMessage::Citizen` wraps citizen lifecycle
+//! events from the dispatcher; the rest are domain events the panels
+//! and drain loop produce.
+
+use egui_citizen::CitizenMessage;
+
+#[derive(Debug, Clone)]
+pub enum AppMessage {
+    /// Lifecycle event from the citizen dispatcher.
+    Citizen(CitizenMessage),
+
+    /// Control panel asks the backend to run a job with the current
+    /// `ParamsState` snapshot.
+    Compute,
+
+    /// Audit log — the backend slot handler has already written
+    /// `last_result` / `in_flight` directly to `SharedState`; this
+    /// variant fires the log line so the timing aligns with other
+    /// AppMessage logging.
+    BackendCompleted { value: f64, elapsed_ms: u32 },
+}

--- a/examples/citizen_signal_async/src/panels/control.rs
+++ b/examples/citizen_signal_async/src/panels/control.rs
@@ -1,0 +1,67 @@
+//! Control panel — duration / seed sliders and the Compute button.
+//! Click pushes `AppMessage::Compute` onto the outbox; main.rs drains
+//! it and forwards through `dispatcher::handle` to the work signal.
+
+use eframe::egui;
+use egui_citizen::{CitizenId, CitizenState};
+
+use crate::messages::AppMessage;
+use crate::state::SharedState;
+
+pub struct ControlPanel {
+    pub citizen_id: CitizenId,
+    pub citizen_state: CitizenState,
+    /// Outgoing app-level messages. Populated by show() and drained by
+    /// main.rs each frame.
+    pub outbox: Vec<AppMessage>,
+}
+
+impl ControlPanel {
+    pub fn new(citizen_state: CitizenState) -> Self {
+        Self {
+            citizen_id: CitizenId::new(crate::tabs::CONTROL_ID),
+            citizen_state,
+            outbox: Vec::new(),
+        }
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {
+        ui.heading("Control");
+        ui.add_space(8.0);
+
+        let mut dur = state.params.work_duration_ms.get();
+        if ui
+            .add(egui::Slider::new(&mut dur, 50..=3000).text("duration_ms"))
+            .changed()
+        {
+            state.params.work_duration_ms.set(dur);
+        }
+
+        let mut seed = state.params.seed.get();
+        if ui
+            .add(
+                egui::Slider::new(&mut seed, 0.0..=1.0)
+                    .text("seed")
+                    .fixed_decimals(3),
+            )
+            .changed()
+        {
+            state.params.seed.set(seed);
+        }
+
+        ui.add_space(12.0);
+
+        if ui
+            .add_sized(
+                [ui.available_width(), 28.0],
+                egui::Button::new("Compute"),
+            )
+            .clicked()
+        {
+            self.outbox.push(AppMessage::Compute);
+        }
+
+        ui.add_space(8.0);
+        ui.weak("submits via Signal<WorkRequest> → AsyncDispatcher → Tokio task");
+    }
+}

--- a/examples/citizen_signal_async/src/panels/logger.rs
+++ b/examples/citizen_signal_async/src/panels/logger.rs
@@ -1,0 +1,41 @@
+//! Scrolling log panel — reads `SharedState::log`. Populated by the
+//! drain loop in main.rs (citizen lifecycle + AppMessage trace) and by
+//! the result-slot handler (backend completions).
+
+use eframe::egui;
+use egui_citizen::{CitizenId, CitizenState};
+
+use crate::state::SharedState;
+
+pub struct LoggerPanel {
+    pub citizen_id: CitizenId,
+    pub citizen_state: CitizenState,
+}
+
+impl LoggerPanel {
+    pub fn new(citizen_state: CitizenState) -> Self {
+        Self {
+            citizen_id: CitizenId::new(crate::tabs::LOGGER_ID),
+            citizen_state,
+        }
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {
+        ui.heading("Log");
+        ui.add_space(4.0);
+
+        let log = state.log.get();
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .stick_to_bottom(true)
+            .show(ui, |ui| {
+                if log.is_empty() {
+                    ui.weak("(no events yet)");
+                } else {
+                    for line in log.iter() {
+                        ui.monospace(line);
+                    }
+                }
+            });
+    }
+}

--- a/examples/citizen_signal_async/src/panels/mod.rs
+++ b/examples/citizen_signal_async/src/panels/mod.rs
@@ -1,0 +1,3 @@
+pub mod control;
+pub mod logger;
+pub mod result;

--- a/examples/citizen_signal_async/src/panels/result.rs
+++ b/examples/citizen_signal_async/src/panels/result.rs
@@ -1,0 +1,43 @@
+//! Result panel — displays the latest backend value, with a spinner
+//! while a request is in flight. Reads `last_result` and `in_flight`
+//! through their shared `Dynamic<T>` handles; both are written by the
+//! result-slot handler off the UI thread.
+
+use eframe::egui;
+use egui_citizen::{CitizenId, CitizenState};
+
+use crate::state::SharedState;
+
+pub struct ResultPanel {
+    pub citizen_id: CitizenId,
+    pub citizen_state: CitizenState,
+}
+
+impl ResultPanel {
+    pub fn new(citizen_state: CitizenState) -> Self {
+        Self {
+            citizen_id: CitizenId::new(crate::tabs::RESULT_ID),
+            citizen_state,
+        }
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {
+        ui.heading("Result");
+        ui.add_space(8.0);
+
+        if state.in_flight.get() {
+            ui.horizontal(|ui| {
+                ui.spinner();
+                ui.label("waiting for backend…");
+            });
+            ui.add_space(8.0);
+        }
+
+        ui.label("Latest value:");
+        ui.add_space(4.0);
+        ui.heading(format!("{:.6}", state.last_result.get()));
+
+        ui.add_space(12.0);
+        ui.weak("Updated by the result-slot handler off the UI thread.");
+    }
+}

--- a/examples/citizen_signal_async/src/state.rs
+++ b/examples/citizen_signal_async/src/state.rs
@@ -1,0 +1,71 @@
+//! Shared application state and the boundary types crossing the work
+//! signal/slot bus.
+
+use egui_mobius_reactive::Dynamic;
+
+/// Reactive parameters edited by the Control panel. Snapshotted into a
+/// `WorkRequest` at Compute time so the backend gets a stable owned
+/// value — no reactivity crosses the work boundary.
+pub struct ParamsState {
+    pub work_duration_ms: Dynamic<u32>,
+    pub seed:             Dynamic<f64>,
+}
+
+impl ParamsState {
+    pub fn defaults() -> Self {
+        Self {
+            work_duration_ms: Dynamic::new(500),
+            seed:             Dynamic::new(0.25),
+        }
+    }
+
+    pub fn snapshot(&self) -> WorkRequest {
+        WorkRequest {
+            duration_ms: self.work_duration_ms.get(),
+            seed:        self.seed.get(),
+        }
+    }
+}
+
+/// Everything the panels read from. Control reads/writes `params`,
+/// Result reads `last_result` and `in_flight`, Logger reads `log`.
+pub struct SharedState {
+    pub params:      ParamsState,
+    pub last_result: Dynamic<f64>,
+    pub in_flight:   Dynamic<bool>,
+    pub log:         Dynamic<Vec<String>>,
+}
+
+impl SharedState {
+    pub fn new() -> Self {
+        Self {
+            params:      ParamsState::defaults(),
+            last_result: Dynamic::new(0.0),
+            in_flight:   Dynamic::new(false),
+            log:         Dynamic::new(Vec::new()),
+        }
+    }
+}
+
+impl Default for SharedState {
+    fn default() -> Self { Self::new() }
+}
+
+// ── Boundary types — values crossing the signal/slot bus ─────────────
+//
+// These travel through the signal bus to the async backend and back.
+// `Send + 'static + Copy` so they ride the channel without lifetime
+// concerns. They will likely move to `backend.rs` in Phase 2 alongside
+// the async work function itself.
+
+#[derive(Debug, Clone, Copy)]
+pub struct WorkRequest {
+    pub duration_ms: u32,
+    pub seed:        f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WorkResponse {
+    pub value:      f64,
+    pub elapsed_ms: u32,
+}

--- a/examples/citizen_signal_async/src/tabs.rs
+++ b/examples/citizen_signal_async/src/tabs.rs
@@ -1,0 +1,78 @@
+//! Tab definitions and the `TabViewer` bridge into `egui_dock`.
+
+use eframe::egui;
+use egui_citizen::{CitizenId, Dispatcher as CitizenDispatcher};
+
+use crate::panels::{control::ControlPanel, logger::LoggerPanel, result::ResultPanel};
+use crate::state::SharedState;
+
+pub const CONTROL_ID: &str = "control";
+pub const RESULT_ID:  &str = "result";
+pub const LOGGER_ID:  &str = "logger";
+
+#[derive(Clone, Copy)]
+pub enum TabKind {
+    Control,
+    Result,
+    Logger,
+}
+
+pub struct Tab {
+    pub kind: TabKind,
+}
+
+impl Tab {
+    pub fn new(kind: TabKind) -> Self { Self { kind } }
+
+    pub fn title(&self) -> &'static str {
+        match self.kind {
+            TabKind::Control => "Control",
+            TabKind::Result  => "Result",
+            TabKind::Logger  => "Logger",
+        }
+    }
+
+    pub fn citizen_id(&self) -> CitizenId {
+        CitizenId::new(match self.kind {
+            TabKind::Control => CONTROL_ID,
+            TabKind::Result  => RESULT_ID,
+            TabKind::Logger  => LOGGER_ID,
+        })
+    }
+}
+
+/// Bridge between `egui_dock` and the citizen layer.
+///
+/// `ui()` routes to each panel's render method. `on_tab_button`
+/// forwards click events into `dispatcher.activate(...)` — the
+/// canonical citizen hook so the dispatcher's queue stays accurate
+/// even if the app doesn't currently drive behavior off activation.
+pub struct TabViewer<'a> {
+    pub state: &'a SharedState,
+    pub dispatcher: &'a mut CitizenDispatcher,
+    pub control: &'a mut ControlPanel,
+    pub result:  &'a mut ResultPanel,
+    pub logger:  &'a mut LoggerPanel,
+}
+
+impl egui_dock::TabViewer for TabViewer<'_> {
+    type Tab = Tab;
+
+    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+        tab.title().into()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+        match tab.kind {
+            TabKind::Control => self.control.show(ui, self.state),
+            TabKind::Result  => self.result.show(ui, self.state),
+            TabKind::Logger  => self.logger.show(ui, self.state),
+        }
+    }
+
+    fn on_tab_button(&mut self, tab: &mut Self::Tab, response: &egui::Response) {
+        if response.clicked() {
+            self.dispatcher.activate(&tab.citizen_id());
+        }
+    }
+}

--- a/examples/citizen_signal_async/task_findings.md
+++ b/examples/citizen_signal_async/task_findings.md
@@ -1,0 +1,150 @@
+# Findings — egui_mobius signal/slot + AsyncDispatcher + egui_citizen
+
+Research notes gathered before writing `citizen_signal_async`. The
+goal of this file is to anchor the design in real APIs that exist in
+the workspace today, not in invented ones.
+
+## The two `Dispatcher`s are unrelated
+
+`egui_mobius` and `egui_citizen` each export a type named `Dispatcher`,
+and they have nothing to do with each other:
+
+- `egui_citizen::Dispatcher` — panel lifecycle. `register()` /
+  `activate()` / `drain_messages()`. Single-threaded, UI-side.
+- `egui_mobius::Dispatcher<E>` — synchronous signal-slot bus.
+  `register_slot(channel, fn)` / `send(channel, event)`.
+- `egui_mobius::dispatching::AsyncDispatcher<E, R>` — the same idea
+  but spins up a Tokio runtime and runs slots as async tasks.
+
+This example uses `egui_citizen::Dispatcher` for panel lifecycle and
+`egui_mobius::dispatching::AsyncDispatcher` for backend work. Both
+must be in scope at once. Convention used in existing examples:
+qualified paths (`use egui_citizen::Dispatcher as CitizenDispatcher`
+or fully-qualified `egui_mobius::dispatching::AsyncDispatcher`).
+
+## Signal / Slot
+
+From `crates/egui_mobius/src/`:
+
+```rust,ignore
+// signals.rs
+pub struct Signal<T> { /* sender side */ }
+impl<T> Signal<T> {
+    pub fn send(&self, msg: T) -> Result<(), String>;
+    pub fn send_multiple(&self, vec: Vec<T>) -> Result<(), String>;
+}
+
+// slot.rs
+pub struct Slot<T> { /* receiver side */ }
+impl<T: Send + 'static> Slot<T> {
+    pub fn start<F>(&mut self, handler: F)
+        where F: FnMut(T) + Send + 'static;
+    pub fn start_async<F, Fut>(&mut self, handler: F);
+}
+
+// factory.rs
+pub fn create_signal_slot<T>() -> (Signal<T>, Slot<T>);
+```
+
+`Signal<T>` is cheap to clone and `Send` — backend threads hold one
+to push back to the UI. `Slot<T>::start` consumes the receiver and
+spawns its own thread to drive the handler. **Each `(Signal, Slot)`
+pair is point-to-point, not multicast.** Fan-out to multiple
+consumers means either multiple signal/slot pairs, or a single slot
+whose handler does all the consumer work in its closure.
+
+## AsyncDispatcher
+
+From `crates/egui_mobius/src/dispatching.rs`:
+
+```rust,ignore
+pub struct AsyncDispatcher<E, R> { /* internals */ }
+impl<E, R> AsyncDispatcher<E, R> {
+    pub fn new() -> Self;        // brings up a tokio runtime
+    pub fn attach_async<F, Fut>(
+        &self,
+        slot: Slot<E>,
+        signal: Signal<R>,
+        handler: F,
+    ) where F: Fn(E) -> Fut + Send + Sync + 'static,
+           Fut: Future<Output = R> + Send + 'static;
+}
+```
+
+`attach_async` is the bridge: a `Slot<E>` (UI-thread input) becomes
+the input to an async handler whose return value is pushed back via
+`Signal<R>`. The handler runs on the dispatcher's Tokio runtime, so
+it can `.await` freely.
+
+## Wiring pattern — taken from `examples/clock_async/src/main.rs`
+
+Verbatim, from lines 155–174:
+
+```rust,ignore
+let (event_signal, event_slot) = factory::create_signal_slot::<Event>();
+let (response_signal, response_slot) = factory::create_signal_slot::<Response>();
+
+let dispatcher = AsyncDispatcher::new();
+dispatcher.attach_async(
+    event_slot,
+    response_signal.clone(),
+    |event: Event| async move {
+        match event {
+            Event::SliderChanged(val) => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                Response::SliderProcessed(val)
+            }
+            // ...
+        }
+    },
+);
+```
+
+UI side, lines 24–42, uses `response_slot.start(|resp| { ... })` to
+receive results on the UI thread and write to shared state.
+
+Backend-thread send-back, lines 107–119: a separate worker thread
+holds a `Signal<ClockMessage>` and calls `.send(...)` on it; the UI
+thread has the matching slot.
+
+## egui_citizen integration surface
+
+`egui_citizen::Dispatcher` does not know about signals at all. The
+bridge between the two worlds happens in the UI update loop:
+
+1. UI thread calls `citizen_dispatcher.drain_messages()` once per
+   frame and routes any `CitizenMessage` it cares about through to
+   `signal.send(...)`.
+2. Backend thread emits results via `signal.send(response)`; the UI
+   thread's matching `Slot::start(...)` handler writes the response
+   into `Dynamic<T>` cells (Path A) and/or appends a log line.
+
+In other words: `egui_citizen::Dispatcher` is the entry point on the
+UI side; `Signal` / `AsyncDispatcher` are the cross-thread bus
+beyond that. There is no library-level glue — the glue is two
+function calls in `App::update`.
+
+## Required imports for the example
+
+```rust,ignore
+use egui_citizen::{
+    Dispatcher as CitizenDispatcher, CitizenId, CitizenMessage, CitizenState, Citizen,
+};
+use egui_mobius::{Signal, Slot};
+use egui_mobius::factory;
+use egui_mobius::dispatching::AsyncDispatcher;
+use egui_mobius_reactive::Dynamic;
+```
+
+## Gotchas to remember
+
+- **`Slot::start` consumes the receiver.** You can't have two slots
+  reading the same channel; for fan-out, emit on multiple signals.
+- **`AsyncDispatcher::new()` spins up a Tokio runtime.** Don't also
+  call `#[tokio::main]` on `main` — single runtime per process.
+- **Panel `Dispatcher` clones share storage** (`egui_citizen` rule)
+  but `Signal<T>` clones share *channel*, not value. Different
+  semantics; don't mentally collapse them.
+- **One-frame latency from backend → UI.** The slot handler runs on
+  the slot's worker thread, writes to a `Dynamic<T>`; egui sees the
+  new value on the next frame. Same single-frame delay as Path B.

--- a/examples/citizen_signal_async/task_plan.md
+++ b/examples/citizen_signal_async/task_plan.md
@@ -1,0 +1,161 @@
+# Plan — citizen_signal_async
+
+## What this example demonstrates
+
+The intersection of the citizen pattern and `egui_mobius`'s
+signal/slot bus, with a Tokio-async backend. Specifically: how a
+citizen-pattern app gets *off the UI thread* without abandoning the
+citizen abstraction, by using `Signal` / `AsyncDispatcher` as the
+cross-thread bridge.
+
+This is the "advanced" path foreshadowed in the introduction:
+
+> `egui_mobius` Signals and Slots can be employed by the dispatcher
+> for more advanced applications, in which case there is likely
+> multiple background threads all receiving a signal from the
+> dispatcher. Each background thread can then send a Signal back to
+> a Slot on the dispatcher for task / thread completion.
+
+## Panels
+
+Three citizen panels in an `egui_dock` layout:
+
+1. **Control** — a slider (work duration, ms) and a "Compute" button.
+   Click sends a `WorkRequest` through the signal bus.
+2. **Result** — displays the most recent `WorkResponse` value as a
+   reactive `Dynamic<f64>`. Spinner while a request is in flight.
+3. **Logger** — append-only scroll of backend events: request
+   submitted, work started (timestamp), work completed, citizen
+   activations.
+
+## State
+
+```rust,ignore
+struct SharedState {
+    work_duration_ms: Dynamic<u32>,    // Control writes
+    last_result:      Dynamic<f64>,    // backend → UI
+    in_flight:        Dynamic<bool>,   // backend → UI; Result panel renders spinner
+    log:              Dynamic<Vec<String>>,  // any-side appends
+}
+```
+
+Each panel holds a clone of `SharedState`. No cross-panel coupling
+beyond the shared `Dynamic`s — Path A only between UI panels.
+
+## Backend types
+
+```rust,ignore
+#[derive(Debug, Clone)]
+struct WorkRequest {
+    duration_ms: u32,
+    seed: f64,
+}
+
+#[derive(Debug, Clone)]
+struct WorkResponse {
+    value: f64,           // computed result (sin of seed * 2π, say)
+    elapsed_ms: u32,
+}
+```
+
+Both are `Send + 'static` (required for the signal bus).
+
+## Wiring (pseudocode)
+
+```rust,ignore
+// At app construction:
+let citizen_dispatcher = CitizenDispatcher::new();
+// Register three citizens, get back CitizenStates …
+
+let async_dispatcher = AsyncDispatcher::<WorkRequest, WorkResponse>::new();
+let (work_signal,   work_slot)   = factory::create_signal_slot::<WorkRequest>();
+let (result_signal, result_slot) = factory::create_signal_slot::<WorkResponse>();
+
+// Hook the backend up to the slot:
+let log = state.log.clone();
+async_dispatcher.attach_async(
+    work_slot,
+    result_signal.clone(),
+    move |req| {
+        let log = log.clone();
+        async move {
+            append(&log, format!("[backend] start, dur={}ms", req.duration_ms));
+            tokio::time::sleep(Duration::from_millis(req.duration_ms as u64)).await;
+            let value = (req.seed * 2.0 * std::f64::consts::PI).sin();
+            append(&log, format!("[backend] done, value={value:.4}"));
+            WorkResponse { value, elapsed_ms: req.duration_ms }
+        }
+    },
+);
+
+// UI-side: receive results
+let last_result = state.last_result.clone();
+let in_flight   = state.in_flight.clone();
+let log         = state.log.clone();
+result_slot.start(move |resp| {
+    last_result.set(resp.value);
+    in_flight.set(false);
+    append(&log, format!("[ui] result received: {:.4}", resp.value));
+});
+
+// Control panel: on Compute click
+work_signal.send(WorkRequest { duration_ms, seed }).unwrap();
+state.in_flight.set(true);
+```
+
+## File layout
+
+```text
+examples/citizen_signal_async/
+├── Cargo.toml
+├── task_plan.md
+├── task_findings.md
+├── task_progress.md
+└── src/
+    ├── main.rs        # eframe::App, dock layout, drain loop
+    ├── state.rs       # SharedState, WorkRequest, WorkResponse
+    ├── tabs.rs        # TabKind, Tab, TabViewer
+    ├── messages.rs    # AppMessage enum (Compute, …)
+    ├── backend.rs     # async work function + signal/slot wiring helper
+    └── panels/
+        ├── mod.rs
+        ├── control.rs
+        ├── result.rs
+        └── logger.rs
+```
+
+Mirrors `filter_plotter` deliberately — anything a reader has
+already learned from the tutorial example transfers verbatim.
+The new material is `backend.rs` and the additional wiring in
+`main.rs`.
+
+## Open questions / decisions to make
+
+- **Tokio runtime ownership.** `AsyncDispatcher::new()` brings up its
+  own runtime. Confirm there is no `#[tokio::main]` collision; the
+  example must run with a plain `fn main()`.
+- **Logger fan-out.** Two options for getting backend events into the
+  Logger panel: (a) the backend's async closure appends directly to
+  `log: Dynamic<Vec<String>>` (cheap, demonstrated above), (b) emit a
+  separate `LogSignal` for backend events and have a third slot
+  subscribed on the UI side. (b) better demonstrates fan-out via a
+  second signal/slot pair; (a) is shorter. Default to (a) for the
+  first cut, mention (b) in a comment.
+- **Citizen activation hookup.** Tab clicks should call
+  `citizen_dispatcher.activate(&id)` per the standard pattern.
+  Drained `Activated` / `Deactivated` messages append to the log
+  alongside backend events — proves both worlds compose in one
+  Logger panel.
+- **In-flight cancellation.** Out of scope for v1. Note this in the
+  README at the end.
+
+## Acceptance for v1
+
+- `cargo run -p citizen_signal_async` opens the dock layout.
+- Move the slider, click Compute. Result panel shows the new value
+  after roughly the slider's duration. Logger shows three lines
+  per click: `[backend] start`, `[backend] done`, `[ui] result`.
+- Click a tab header. Logger shows `Activated { … }` for that
+  citizen. Same `Deactivated { … }` for the previously-active one.
+- No deadlocks if Compute is clicked rapidly; in-flight requests
+  queue and complete in order.

--- a/examples/citizen_signal_async/task_progress.md
+++ b/examples/citizen_signal_async/task_progress.md
@@ -24,19 +24,29 @@ clean before moving on.
       live here for now; will move to `tabs.rs` in Phase 3.
 - [x] `cargo check` clean (17 unused-item warnings; expected until
       Phase 2 wires the bus and Phase 3 builds the panels)
-- [ ] Minimal eframe app shell in `main.rs` (no panels yet, just a
-      central panel saying "ready")
+- [x] Minimal eframe app shell in `main.rs` (CentralPanel with sliders,
+      Compute button, in-flight spinner, last-result label, log
+      scrollback) — folded into Phase 2 since the shell and the
+      backend wiring are tested together
 
-## Phase 2 — backend wiring
+## Phase 2 — backend wiring + smoke-test shell
 
-- [ ] `src/backend.rs` — async work function + helper that builds the
-      `AsyncDispatcher`, signal/slot pairs, and returns the handles
-      the UI needs (`Signal<WorkRequest>`, `Slot<WorkResponse>`)
-- [ ] Hook the result slot to write `last_result`, `in_flight`,
-      `log` in `SharedState`
-- [ ] Manual smoke test: send a synthetic `WorkRequest` from a button
-      in the central panel; verify `last_result` updates after the
-      sleep
+- [x] `src/backend.rs` — `wire_backend()` builds the `AsyncDispatcher`,
+      both signal/slot pairs, attaches the async `work()` function;
+      returns `Signal<WorkRequest>`, `Slot<WorkResponse>`,
+      `BackendHandle` (keepalive for the Tokio runtime)
+- [x] Result slot handler in `App::new` writes `last_result`,
+      `in_flight`, log line; calls `ctx.request_repaint()` so the UI
+      paints the new value next frame
+- [x] AppMessage drain in `update()` — `outbox` filled by Compute
+      button, drained by `dispatcher::handle`, which forwards to
+      `work_signal.send(req)`
+- [x] `cargo check -p citizen_signal_async` clean (2 unused-item
+      warnings; expected until Phase 3 wires panels through `AppMessage`)
+- [ ] **Manual smoke test (user)**: `cargo run -p citizen_signal_async`,
+      move sliders, click Compute. Expect log lines: `[ui] submit:`,
+      `[backend] result:`, and `last result:` updating after the
+      slider's duration. Spinner shown while in-flight.
 
 ## Phase 3 — citizen panels
 

--- a/examples/citizen_signal_async/task_progress.md
+++ b/examples/citizen_signal_async/task_progress.md
@@ -1,0 +1,60 @@
+# Progress — citizen_signal_async
+
+Build checklist. Update as work proceeds. Each phase should leave the
+crate in a buildable state — `cargo check -p citizen_signal_async`
+clean before moving on.
+
+## Phase 0 — scaffold (this commit)
+
+- [x] Crate directory created at `examples/citizen_signal_async/`
+- [x] `Cargo.toml` with workspace deps (egui_mobius,
+      egui_mobius_reactive, egui_citizen, egui, egui_dock, eframe,
+      tokio)
+- [x] Stub `src/main.rs` (placeholder `fn main()`)
+- [x] `task_plan.md`, `task_findings.md`, `task_progress.md` written
+- [x] Added to root `Cargo.toml` workspace `members`
+- [x] `cargo check -p citizen_signal_async` clean
+
+## Phase 1 — types + state
+
+- [ ] `src/state.rs` — `SharedState`, `WorkRequest`, `WorkResponse`
+- [ ] `src/messages.rs` — `AppMessage` enum
+- [ ] Minimal eframe app shell in `main.rs` (no panels yet, just a
+      central panel saying "ready")
+
+## Phase 2 — backend wiring
+
+- [ ] `src/backend.rs` — async work function + helper that builds the
+      `AsyncDispatcher`, signal/slot pairs, and returns the handles
+      the UI needs (`Signal<WorkRequest>`, `Slot<WorkResponse>`)
+- [ ] Hook the result slot to write `last_result`, `in_flight`,
+      `log` in `SharedState`
+- [ ] Manual smoke test: send a synthetic `WorkRequest` from a button
+      in the central panel; verify `last_result` updates after the
+      sleep
+
+## Phase 3 — citizen panels
+
+- [ ] `src/panels/control.rs`
+- [ ] `src/panels/result.rs` (with spinner on `in_flight`)
+- [ ] `src/panels/logger.rs`
+- [ ] `src/tabs.rs` — `TabKind`, `Tab`, `TabViewer`
+- [ ] `src/main.rs` updated to dock layout + drain loop
+
+## Phase 4 — citizen activation logging
+
+- [ ] Tab clicks call `citizen_dispatcher.activate(&id)`
+- [ ] `drain_messages()` appended to `state.log` so Logger shows
+      both backend events and citizen lifecycle events
+
+## Phase 5 — polish
+
+- [ ] README.md inside the example explaining what to look at
+- [ ] Reference this example from the book's existing
+      "signals and slots can be employed by the dispatcher"
+      paragraph
+- [ ] Add to `examples/README.md` under the citizen pattern section
+
+## Notes / decisions made along the way
+
+(Append dated notes here as design choices come up. Keep terse.)

--- a/examples/citizen_signal_async/task_progress.md
+++ b/examples/citizen_signal_async/task_progress.md
@@ -15,10 +15,15 @@ clean before moving on.
 - [x] Added to root `Cargo.toml` workspace `members`
 - [x] `cargo check -p citizen_signal_async` clean
 
-## Phase 1 — types + state
+## Phase 1 — types + state + dispatcher routing
 
-- [ ] `src/state.rs` — `SharedState`, `WorkRequest`, `WorkResponse`
-- [ ] `src/messages.rs` — `AppMessage` enum
+- [x] `src/state.rs` — `SharedState`, `ParamsState`, `WorkRequest`, `WorkResponse`
+- [x] `src/messages.rs` — `AppMessage` enum
+- [x] `src/dispatcher.rs` — `register_citizens`, `drain_citizen`,
+      `handle()`, `append_log()`, `format_citizen()`. Citizen IDs
+      live here for now; will move to `tabs.rs` in Phase 3.
+- [x] `cargo check` clean (17 unused-item warnings; expected until
+      Phase 2 wires the bus and Phase 3 builds the panels)
 - [ ] Minimal eframe app shell in `main.rs` (no panels yet, just a
       central panel saying "ready")
 

--- a/examples/citizen_signal_async/task_progress.md
+++ b/examples/citizen_signal_async/task_progress.md
@@ -48,19 +48,31 @@ clean before moving on.
       `[backend] result:`, and `last result:` updating after the
       slider's duration. Spinner shown while in-flight.
 
-## Phase 3 — citizen panels
+## Phase 3 — citizen panels + dock layout
 
-- [ ] `src/panels/control.rs`
-- [ ] `src/panels/result.rs` (with spinner on `in_flight`)
-- [ ] `src/panels/logger.rs`
-- [ ] `src/tabs.rs` — `TabKind`, `Tab`, `TabViewer`
-- [ ] `src/main.rs` updated to dock layout + drain loop
+- [x] `src/panels/mod.rs` — module root
+- [x] `src/panels/control.rs` — duration / seed sliders + Compute
+      button → `outbox.push(AppMessage::Compute)`
+- [x] `src/panels/result.rs` — last_result heading + in_flight spinner
+- [x] `src/panels/logger.rs` — log scrollback (mirrors filter_plotter)
+- [x] `src/tabs.rs` — `TabKind`, `Tab`, `TabViewer`. Citizen IDs moved
+      here from `dispatcher.rs` (their canonical home alongside
+      `TabKind`).
+- [x] `src/main.rs` rewritten: `DockArea` + `TabViewer`, layout is
+      `Result | (Control / Logger)`. Drain loop unchanged.
+- [x] `cargo check` clean (4 unused-item warnings on panel
+      `citizen_id` / `citizen_state` fields — same warnings
+      filter_plotter has; convention is to leave them in)
+- [ ] **Manual smoke test (user)**: dock layout opens, Compute on the
+      Control panel updates the Result panel, tab clicks log
+      `[citizen] X activated/deactivated` lines in the Logger.
 
-## Phase 4 — citizen activation logging
+## Phase 4 — citizen activation logging (already done in Phase 3)
 
-- [ ] Tab clicks call `citizen_dispatcher.activate(&id)`
-- [ ] `drain_messages()` appended to `state.log` so Logger shows
-      both backend events and citizen lifecycle events
+- [x] Tab clicks call `citizen_dispatcher.activate(&id)` (via
+      `TabViewer::on_tab_button`)
+- [x] `drain_messages()` appended to `state.log` so Logger shows both
+      backend events and citizen lifecycle events
 
 ## Phase 5 — polish
 


### PR DESCRIPTION
## Summary

- New tier-3 example crate `citizen_signal_async` demonstrating the citizen pattern paired with `egui_mobius`'s signal/slot bus and a Tokio async backend. Click Compute → `Signal<WorkRequest>` → `AsyncDispatcher` → Tokio task → `Signal<WorkResponse>` → result-slot handler writes through shared `Dynamic<T>` and requests UI repaint.
- Three docked citizens (Result / Control / Logger) wired through `egui_dock::TabViewer`. Tab clicks forward to `Dispatcher::activate`; the existing drain loop logs lifecycle messages alongside backend events in the Logger panel.
- Book intro now names the three application levels (panels-only → dispatcher-with-backend → dispatcher-with-signals-and-slots) and links each level to its worked example, so readers can map their use case onto the ecosystem in one paragraph.

## What's in the example

\`examples/citizen_signal_async/\`:

- \`state.rs\` — \`SharedState\` (reactive \`Dynamic<T>\` for params, result, in-flight, log) + boundary types \`WorkRequest\` / \`WorkResponse\`
- \`messages.rs\` — \`AppMessage\` enum
- \`dispatcher.rs\` — \`register_citizens\` / \`drain_citizen\` / \`handle()\` mirroring \`filter_plotter::dispatcher\` but with \`Signal<WorkRequest>\` as the work boundary
- \`backend.rs\` — \`wire_backend()\` returns the UI-side handles and a \`BackendHandle\` keepalive for the Tokio runtime
- \`panels/{control, result, logger}.rs\` — three citizen panels
- \`tabs.rs\` — \`TabKind\`, \`Tab\`, \`TabViewer\`; owns the citizen IDs
- \`task_plan.md\` / \`task_findings.md\` / \`task_progress.md\` — design / API research / phase checklist, kept in-tree as long-form docs that explain the design

## Book changes

- Title broadens to \`egui-mobius && egui-citizen\` to reflect the book's actual scope.
- Introduction's three-level paragraph gets a short bullet list mapping each level to its examples.

## Test plan

- [ ] \`cargo build --workspace\` clean
- [ ] \`cargo run -p citizen_signal_async\` opens with three docked panels
- [ ] Move duration slider, click Compute → spinner appears, result updates after the slider's duration
- [ ] Logger shows three lines per click: \`[ui] submit:\`, \`[backend] result:\`, plus the \`[INFO]\` startup line
- [ ] Click each tab header → Logger shows \`[citizen] X activated\` / \`[citizen] Y deactivated\`
- [ ] Rapid Compute clicks queue and complete in order; no UI freeze
- [ ] \`mdbook build\` from \`book/\` clean
- [ ] Book intro renders with the level → example bullet list