### PR TITLE
Fix all cargo clippy warnings

### DIFF
--- a/examples/citizen_dock/src/main.rs
+++ b/examples/citizen_dock/src/main.rs
@@ -83,22 +83,22 @@ impl egui_dock::TabViewer for TabViewer<'_> {
     }
 
     fn on_tab_button(&mut self, tab: &mut Self::Tab, response: &egui::Response) {
-        if response.clicked() {
-            if let Some(id) = tab.citizen_id() {
-                self.dispatcher.activate(&id);
-                self.active_algo.set(id.0.clone());
+        if response.clicked()
+            && let Some(id) = tab.citizen_id()
+        {
+            self.dispatcher.activate(&id);
+            self.active_algo.set(id.0.clone());
 
-                // Drain messages into the log so we can see the one-hot activation
-                for msg in self.dispatcher.drain_messages() {
-                    match &msg {
-                        CitizenMessage::Activated { id } => {
-                            self.log.push(format!("[CITIZEN] Activated: {id}"));
-                        }
-                        CitizenMessage::Deactivated { id } => {
-                            self.log.push(format!("[CITIZEN] Deactivated: {id}"));
-                        }
-                        _ => {}
+            // Drain messages into the log so we can see the one-hot activation
+            for msg in self.dispatcher.drain_messages() {
+                match &msg {
+                    CitizenMessage::Activated { id } => {
+                        self.log.push(format!("[CITIZEN] Activated: {id}"));
                     }
+                    CitizenMessage::Deactivated { id } => {
+                        self.log.push(format!("[CITIZEN] Deactivated: {id}"));
+                    }
+                    _ => {}
                 }
             }
         }

--- a/examples/citizen_fetch/src/main.rs
+++ b/examples/citizen_fetch/src/main.rs
@@ -113,10 +113,10 @@ impl egui_dock::TabViewer for TabViewer<'_> {
     }
 
     fn on_tab_button(&mut self, tab: &mut Tab, response: &egui::Response) {
-        if response.clicked() {
-            if let Some(id) = tab.citizen_id() {
-                self.dispatcher.activate(&id);
-            }
+        if response.clicked()
+            && let Some(id) = tab.citizen_id()
+        {
+            self.dispatcher.activate(&id);
         }
     }
 

--- a/examples/citizen_signal_async/src/dispatcher.rs
+++ b/examples/citizen_signal_async/src/dispatcher.rs
@@ -6,39 +6,12 @@
 //! async via `egui_mobius`'s signal/slot bus) rather than a synchronous
 //! `BackendKind` trait object run inline on the UI thread.
 
-use egui_citizen::{CitizenId, CitizenMessage, CitizenState, Dispatcher};
+use egui_citizen::{CitizenMessage, Dispatcher};
 use egui_mobius::Signal;
 use egui_mobius_reactive::Dynamic;
 
 use crate::messages::AppMessage;
 use crate::state::{SharedState, WorkRequest};
-use crate::tabs::{CONTROL_ID, LOGGER_ID, RESULT_ID};
-
-/// The three CitizenStates the panels need to hold, kept together so
-/// `App::new()` doesn't have to thread three values out of
-/// `register_citizens`.
-pub struct RegisteredCitizens {
-    pub control: CitizenState,
-    pub result: CitizenState,
-    pub logger: CitizenState,
-}
-
-/// Register the three citizens with the dispatcher and activate
-/// `control` as the default focus. Returns the panel-bound state
-/// handles.
-pub fn register_citizens(dispatcher: &mut Dispatcher) -> RegisteredCitizens {
-    let control = dispatcher.register(CitizenId::new(CONTROL_ID));
-    let result = dispatcher.register(CitizenId::new(RESULT_ID));
-    let logger = dispatcher.register(CitizenId::new(LOGGER_ID));
-
-    dispatcher.activate(&CitizenId::new(CONTROL_ID));
-
-    RegisteredCitizens {
-        control,
-        result,
-        logger,
-    }
-}
 
 /// Drain citizen lifecycle messages and append them to the shared log.
 /// Call once per frame after `DockArea::show`.
@@ -60,9 +33,6 @@ pub fn handle(
     log: &Dynamic<Vec<String>>,
 ) {
     match msg {
-        // Already drained directly via `drain_citizen`.
-        AppMessage::Citizen(_) => {}
-
         AppMessage::Compute => {
             let req = state.params.snapshot();
             state.in_flight.set(true);
@@ -77,16 +47,6 @@ pub fn handle(
                 append_log(log, format!("[ui] send failed: {e}"));
                 state.in_flight.set(false);
             }
-        }
-
-        AppMessage::BackendCompleted { value, elapsed_ms } => {
-            append_log(
-                log,
-                format!(
-                    "[ui] backend completed: value={:.4} elapsed_ms={}",
-                    value, elapsed_ms,
-                ),
-            );
         }
     }
 }

--- a/examples/citizen_signal_async/src/main.rs
+++ b/examples/citizen_signal_async/src/main.rs
@@ -43,8 +43,7 @@ impl App {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
         let state = SharedState::new();
 
-        let mut dispatcher = CitizenDispatcher::new();
-        let citizens = dispatcher::register_citizens(&mut dispatcher);
+        let dispatcher = CitizenDispatcher::new();
 
         // Dock layout:
         //   ┌──────────────┬─────────────┐
@@ -93,9 +92,9 @@ impl App {
             state,
             work_signal,
             _backend: backend_handle,
-            control: ControlPanel::new(citizens.control),
-            result: ResultPanel::new(citizens.result),
-            logger: LoggerPanel::new(citizens.logger),
+            control: ControlPanel::new(),
+            result: ResultPanel::new(),
+            logger: LoggerPanel::new(),
         }
     }
 }

--- a/examples/citizen_signal_async/src/messages.rs
+++ b/examples/citizen_signal_async/src/messages.rs
@@ -2,20 +2,9 @@
 //! events from the dispatcher; the rest are domain events the panels
 //! and drain loop produce.
 
-use egui_citizen::CitizenMessage;
-
 #[derive(Debug, Clone)]
 pub enum AppMessage {
-    /// Lifecycle event from the citizen dispatcher.
-    Citizen(CitizenMessage),
-
     /// Control panel asks the backend to run a job with the current
     /// `ParamsState` snapshot.
     Compute,
-
-    /// Audit log — the backend slot handler has already written
-    /// `last_result` / `in_flight` directly to `SharedState`; this
-    /// variant fires the log line so the timing aligns with other
-    /// AppMessage logging.
-    BackendCompleted { value: f64, elapsed_ms: u32 },
 }

--- a/examples/citizen_signal_async/src/panels/control.rs
+++ b/examples/citizen_signal_async/src/panels/control.rs
@@ -3,26 +3,19 @@
 //! it and forwards through `dispatcher::handle` to the work signal.
 
 use eframe::egui;
-use egui_citizen::{CitizenId, CitizenState};
 
 use crate::messages::AppMessage;
 use crate::state::SharedState;
 
 pub struct ControlPanel {
-    pub citizen_id: CitizenId,
-    pub citizen_state: CitizenState,
     /// Outgoing app-level messages. Populated by show() and drained by
     /// main.rs each frame.
     pub outbox: Vec<AppMessage>,
 }
 
 impl ControlPanel {
-    pub fn new(citizen_state: CitizenState) -> Self {
-        Self {
-            citizen_id: CitizenId::new(crate::tabs::CONTROL_ID),
-            citizen_state,
-            outbox: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self { outbox: Vec::new() }
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {

--- a/examples/citizen_signal_async/src/panels/logger.rs
+++ b/examples/citizen_signal_async/src/panels/logger.rs
@@ -3,21 +3,14 @@
 //! the result-slot handler (backend completions).
 
 use eframe::egui;
-use egui_citizen::{CitizenId, CitizenState};
 
 use crate::state::SharedState;
 
-pub struct LoggerPanel {
-    pub citizen_id: CitizenId,
-    pub citizen_state: CitizenState,
-}
+pub struct LoggerPanel {}
 
 impl LoggerPanel {
-    pub fn new(citizen_state: CitizenState) -> Self {
-        Self {
-            citizen_id: CitizenId::new(crate::tabs::LOGGER_ID),
-            citizen_state,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {

--- a/examples/citizen_signal_async/src/panels/result.rs
+++ b/examples/citizen_signal_async/src/panels/result.rs
@@ -4,21 +4,14 @@
 //! result-slot handler off the UI thread.
 
 use eframe::egui;
-use egui_citizen::{CitizenId, CitizenState};
 
 use crate::state::SharedState;
 
-pub struct ResultPanel {
-    pub citizen_id: CitizenId,
-    pub citizen_state: CitizenState,
-}
+pub struct ResultPanel {}
 
 impl ResultPanel {
-    pub fn new(citizen_state: CitizenState) -> Self {
-        Self {
-            citizen_id: CitizenId::new(crate::tabs::RESULT_ID),
-            citizen_state,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {

--- a/examples/dashboard/src/main.rs
+++ b/examples/dashboard/src/main.rs
@@ -122,13 +122,12 @@ impl UiApp {
 
 impl eframe::App for UiApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = ui.ctx();
         {
             let mut app_state = self.state.lock().unwrap();
 
             //let mut app_state = self.state.get();
 
-            egui::TopBottomPanel::bottom("log_panel")
+            egui::Panel::bottom("log_panel")
                 .resizable(true)
                 .show_inside(ui, |ui| {
                     ui.heading("Logs");

--- a/examples/dashboard_async/src/main.rs
+++ b/examples/dashboard_async/src/main.rs
@@ -16,7 +16,6 @@
 ///
 /// James Bonanno, <atlantix-eda@proton.me>, 15 March 2025
 ///
-use egui::Context;
 use egui_mobius::dispatching::AsyncDispatcher;
 use egui_mobius::factory;
 use egui_mobius::signals::*;

--- a/examples/filter_plotter/src/dispatcher.rs
+++ b/examples/filter_plotter/src/dispatcher.rs
@@ -5,38 +5,12 @@
 //! shell + dock layout) and gives the dispatcher code one place to
 //! evolve as the app grows.
 
-use egui_citizen::{CitizenId, CitizenMessage, CitizenState, Dispatcher};
+use egui_citizen::{CitizenMessage, Dispatcher};
 use egui_mobius_reactive::Dynamic;
 
 use crate::backend::BackendKind;
 use crate::messages::AppMessage;
 use crate::state::SharedState;
-use crate::tabs::{LOGGER_ID, PLOT_ID, SETTINGS_ID};
-
-/// The three CitizenStates the app's panels need to hold, kept in a
-/// single struct so the App doesn't have to thread three values out of
-/// `register_citizens`.
-pub struct RegisteredCitizens {
-    pub plot: CitizenState,
-    pub settings: CitizenState,
-    pub logger: CitizenState,
-}
-
-/// Register the three citizens with the dispatcher and activate `plot`
-/// as the default focus. Returns the panel-bound state handles.
-pub fn register_citizens(dispatcher: &mut Dispatcher) -> RegisteredCitizens {
-    let plot = dispatcher.register(CitizenId::new(PLOT_ID));
-    let settings = dispatcher.register(CitizenId::new(SETTINGS_ID));
-    let logger = dispatcher.register(CitizenId::new(LOGGER_ID));
-
-    dispatcher.activate(&CitizenId::new(PLOT_ID));
-
-    RegisteredCitizens {
-        plot,
-        settings,
-        logger,
-    }
-}
 
 /// Drain citizen lifecycle messages from the dispatcher and append them
 /// to the shared log. Call once per frame after `DockArea::show`.
@@ -53,9 +27,6 @@ where
     B: BackendKind<Sample = f32>,
 {
     match msg {
-        // Already drained directly via `drain_citizen`.
-        AppMessage::Citizen(_) => {}
-
         AppMessage::Generate => {
             let params = state.params.snapshot();
             let traces = backend.run(&params);
@@ -64,13 +35,6 @@ where
             append_log(
                 log,
                 format!("[INFO] backend ({}) produced {} samples", backend.name(), n,),
-            );
-        }
-
-        AppMessage::GenerateCompleted { samples } => {
-            append_log(
-                log,
-                format!("[INFO] generate completed: {} samples", samples),
             );
         }
     }

--- a/examples/filter_plotter/src/main.rs
+++ b/examples/filter_plotter/src/main.rs
@@ -39,8 +39,7 @@ impl App {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
         theme::apply_visuals(&cc.egui_ctx);
 
-        let mut dispatcher_handle = Dispatcher::new();
-        let citizens = dispatcher::register_citizens(&mut dispatcher_handle);
+        let dispatcher_handle = Dispatcher::new();
 
         // Dock layout:
         //   ┌──────────────┬─────────────┐
@@ -66,9 +65,9 @@ impl App {
             dispatcher: dispatcher_handle,
             dock_state,
             state,
-            plot: PlotPanel::new(citizens.plot),
-            settings: SettingsPanel::new(citizens.settings),
-            logger: LoggerPanel::new(citizens.logger),
+            plot: PlotPanel::new(),
+            settings: SettingsPanel::new(),
+            logger: LoggerPanel::new(),
             backend: InProcessIir::new(),
         }
     }

--- a/examples/filter_plotter/src/messages.rs
+++ b/examples/filter_plotter/src/messages.rs
@@ -2,18 +2,9 @@
 //! events from the dispatcher; the rest are domain events the panels and
 //! drain loop produce.
 
-use egui_citizen::CitizenMessage;
-
 #[derive(Debug, Clone)]
 pub enum AppMessage {
-    /// Lifecycle event from the citizen dispatcher.
-    Citizen(CitizenMessage),
-
     /// Settings panel asks the backend to generate a new pair of traces
     /// from the current parameters.
     Generate,
-
-    /// Backend reports a finished run. (Used here as a log signal —
-    /// the traces themselves are written to SharedState directly.)
-    GenerateCompleted { samples: usize },
 }

--- a/examples/filter_plotter/src/panels/logger.rs
+++ b/examples/filter_plotter/src/panels/logger.rs
@@ -2,21 +2,14 @@
 //! drain loop in main.rs.
 
 use eframe::egui;
-use egui_citizen::{CitizenId, CitizenState};
 
 use crate::state::SharedState;
 
-pub struct LoggerPanel {
-    pub citizen_id: CitizenId,
-    pub citizen_state: CitizenState,
-}
+pub struct LoggerPanel {}
 
 impl LoggerPanel {
-    pub fn new(citizen_state: CitizenState) -> Self {
-        Self {
-            citizen_id: CitizenId::new(crate::tabs::LOGGER_ID),
-            citizen_state,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {

--- a/examples/filter_plotter/src/panels/plot.rs
+++ b/examples/filter_plotter/src/panels/plot.rs
@@ -3,7 +3,6 @@
 //! plot drives both, matplotlib-style.
 
 use eframe::egui;
-use egui_citizen::{CitizenId, CitizenState};
 use egui_plot::{Line, Plot, PlotPoints};
 
 use crate::state::SharedState;
@@ -24,17 +23,11 @@ use crate::state::SharedState;
 const INPUT_STRIDE: usize = 1;
 const FILTERED_STRIDE: usize = 50;
 
-pub struct PlotPanel {
-    pub citizen_id: CitizenId,
-    pub citizen_state: CitizenState,
-}
+pub struct PlotPanel {}
 
 impl PlotPanel {
-    pub fn new(citizen_state: CitizenState) -> Self {
-        Self {
-            citizen_id: CitizenId::new(crate::tabs::PLOT_ID),
-            citizen_state,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState) {

--- a/examples/filter_plotter/src/panels/settings.rs
+++ b/examples/filter_plotter/src/panels/settings.rs
@@ -3,26 +3,20 @@
 //! the backend.
 
 use eframe::egui;
-use egui_citizen::{CitizenId, CitizenState, Dispatcher};
+use egui_citizen::Dispatcher;
 
 use crate::messages::AppMessage;
 use crate::state::SharedState;
 
 pub struct SettingsPanel {
-    pub citizen_id: CitizenId,
-    pub citizen_state: CitizenState,
     /// Outgoing app-level messages routed through the dispatcher.
     /// Populated by show() and drained by main.rs each frame.
     pub outbox: Vec<AppMessage>,
 }
 
 impl SettingsPanel {
-    pub fn new(citizen_state: CitizenState) -> Self {
-        Self {
-            citizen_id: CitizenId::new(crate::tabs::SETTINGS_ID),
-            citizen_state,
-            outbox: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self { outbox: Vec::new() }
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui, state: &SharedState, _dispatcher: &mut Dispatcher) {

--- a/examples/filter_plotter/src/theme.rs
+++ b/examples/filter_plotter/src/theme.rs
@@ -12,10 +12,3 @@ pub fn apply_visuals(ctx: &egui::Context) {
     v.extreme_bg_color = Color32::from_rgb(0x16, 0x16, 0x1e);
     ctx.set_visuals(v);
 }
-
-/// Apply a global UI font scale (100 = default). Useful on high-DPI
-/// displays or for screen-recording the demo at a larger size.
-pub fn apply_font_scale(ctx: &egui::Context, scale_pct: u32) {
-    let scale = (scale_pct.max(50).min(200)) as f32 / 100.0;
-    ctx.set_pixels_per_point(scale);
-}

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -150,10 +150,10 @@ impl egui_dock::TabViewer for TabViewer<'_> {
     }
 
     fn on_tab_button(&mut self, tab: &mut Tab, response: &egui::Response) {
-        if response.clicked() {
-            if let Some(id) = tab.citizen_id() {
-                self.dispatcher.activate(&id);
-            }
+        if response.clicked()
+            && let Some(id) = tab.citizen_id()
+        {
+            self.dispatcher.activate(&id);
         }
     }
 
@@ -237,7 +237,6 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = ui.ctx();
         // Step 2 + 3: Render dock, then drain messages
         let mut dock_state = self.dock_state.clone();
         let mut dispatcher = std::mem::take(&mut self.dispatcher);

--- a/examples/reactive_slider/src/main.rs
+++ b/examples/reactive_slider/src/main.rs
@@ -1,4 +1,4 @@
-use egui::{CentralPanel, Context};
+use egui::CentralPanel;
 use egui_mobius_reactive::*;
 
 use eframe::{App, Frame};


### PR DESCRIPTION
Builds on top of #17 and removes all of the warnings that immitted during a cargo clippy passthrough. This library can now run cargo fmt without changing any code, and cargo clippy without any warnings.